### PR TITLE
Fixed mixed indentation types

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
     <head>
-    	<meta http-equiv="refresh"
-    		  content="0; url=https://brain-labs.github.io/brain/docs/html" />
+      <meta http-equiv="refresh"
+            content="0; url=https://brain-labs.github.io/brain/docs/html" />
     </head>
     <body></body>
 </html>

--- a/libs/install.sh
+++ b/libs/install.sh
@@ -6,7 +6,7 @@ inc_path=/usr/local/include/brain
 
 mkdir -p $inc_path
 if [ $? -ne 0 ] ; then
-  exit  
+  exit
 fi
 
 files=$(find $1 -type f -name "*.c")
@@ -15,11 +15,11 @@ if [ $? -ne 0 ] ; then
   exit
 fi
 
-for lib in $files 
+for lib in $files
 do
   filename=$(basename "$lib")
   filename="${filename%.*}"
-  clang -S -emit-llvm $lib -o $inc_path/$filename.ll  
+  clang -S -emit-llvm $lib -o $inc_path/$filename.ll
   if [ $? -ne 0 ] ; then
     exit
   else

--- a/libs/io.c
+++ b/libs/io.c
@@ -6,7 +6,7 @@ void b_getchar(int idx, int *cells) {
   cells[idx] = getchar();
 }
 
-void b_putchar(int idx, int *cells) { 
+void b_putchar(int idx, int *cells) {
   putchar(cells[idx]);
 }
 

--- a/src/ast/expr/ArithmeticExpr.cpp
+++ b/src/ast/expr/ArithmeticExpr.cpp
@@ -16,7 +16,7 @@ void ArithmeticExpr::code_gen(llvm::Module *M, llvm::IRBuilder<> &B,
     llvm::Value* Idxs[] = { B.getInt32(0), IdxV };
     llvm::ArrayRef<llvm::Value *> IdxsArr(Idxs);
     llvm::Value *CellPtr = B.CreateGEP(ASTInfo::instance()->get_cells_ptr(),
-									   IdxsArr);
+                                       IdxsArr);
     // Load cell value
     llvm::Value *CellV = B.CreateLoad(CellPtr);
 
@@ -25,7 +25,7 @@ void ArithmeticExpr::code_gen(llvm::Module *M, llvm::IRBuilder<> &B,
     llvm::Value* Idxs2[] = { B.getInt32(0), IdxPreV };
     llvm::ArrayRef<llvm::Value *> IdxsArr2(Idxs2);
     llvm::Value *CellPtr2 = B.CreateGEP(ASTInfo::instance()->get_cells_ptr(),
-										IdxsArr2);
+                                        IdxsArr2);
     // Load cell value
     llvm::Value *CellV2 = B.CreateLoad(CellPtr2);
 
@@ -74,7 +74,7 @@ void ArithmeticExpr::ast_code_gen()
         arithmetic_char = TT_REM;
         break;
     }
-    
+
     std::cout << (char)arithmetic_char;
 }
 

--- a/src/ast/expr/ArithmeticExpr.h
+++ b/src/ast/expr/ArithmeticExpr.h
@@ -39,9 +39,9 @@ protected:
 public:
     ArithmeticExpr(ArithmeticType type) : _type(type) {}
     ~ArithmeticExpr() {}
-	/**
+    /**
      * @brief Generates the IR (Intermediate Representation) code to be
-	 * executed by llvm.
+     * executed by llvm.
      * @param M A pointer to the Brain's module.
      * @param B A reference to the Brain's IR builder.
      * @param BreakBB A pointer to the Brain's basic block.
@@ -50,9 +50,9 @@ public:
                   llvm::BasicBlock *BreakBB);
     /**
      * @brief Prints debug information when Brain's compiler has the active
-	 * flags: -v | -emit-ast.
+     * flags: -v | -emit-ast.
      * @param level The width used to display the debug information (to mimic
-	 * identation).
+     * identation).
      */
     void debug_description(int level);
     /**

--- a/src/ast/expr/BreakExpr.h
+++ b/src/ast/expr/BreakExpr.h
@@ -24,9 +24,9 @@ class BreakExpr : public Expr
 public:
     BreakExpr() {}
     ~BreakExpr() {}
-	/**
+    /**
      * @brief Generates the IR (Intermediate Representation) code to be
-	 * executed by llvm.
+     * executed by llvm.
      * @param M A pointer to the Brain's module.
      * @param B A reference to the Brain's IR builder.
      * @param BreakBB A pointer to the Brain's basic block.
@@ -35,9 +35,9 @@ public:
                   llvm::BasicBlock *BreakBB);
     /**
      * @brief Prints debug information when Brain's compiler has the active
-	 * flags: -v | -emit-ast.
+     * flags: -v | -emit-ast.
      * @param level The width used to display the debug information (to mimic
-	 * identation).
+     * identation).
      */
     void debug_description(int level);
     /**
@@ -45,7 +45,7 @@ public:
      * out to the stdout the token itself.
      */
     void ast_code_gen();
-	/**
+    /**
      * @brief Returns the category of the expression given by the caller.
      */
     ExpressionType expression_category();

--- a/src/ast/expr/DebugExpr.cpp
+++ b/src/ast/expr/DebugExpr.cpp
@@ -26,7 +26,7 @@ void DebugExpr::debug_description(int level)
 {
   std::cout.width(level);
   if (ArgsOptions::instance()->has_option(BO_IS_VERBOSE)) {
-    std::cout << "Debug Expression" 
+    std::cout << "Debug Expression"
               << std::endl;
   }
   else {

--- a/src/ast/expr/IfExpr.cpp
+++ b/src/ast/expr/IfExpr.cpp
@@ -22,12 +22,12 @@ void IfExpr::code_gen(llvm::Module *M, llvm::IRBuilder<> &B,
     llvm::Value *IdxV = B.CreateLoad(ASTInfo::instance()->get_index_ptr());
     llvm::Value *CellPtr = B.CreateGEP(B.CreatePointerCast(ASTInfo::instance()->get_cells_ptr(),
                                                            // Cast to int32*
-                                                           llvm::Type::getInt32Ty(C)->getPointerTo()), 
+                                                           llvm::Type::getInt32Ty(C)->getPointerTo()),
                                        IdxV);
     llvm::Value *NEZeroCond = B.CreateICmpNE(B.CreateLoad(CellPtr),
                                              // is cell signed int not equal
                                              // to zero?
-                                             B.getInt32(0)); 
+                                             B.getInt32(0));
 
     if (ArgsOptions::instance()->get_optimization() == BO_IS_OPTIMIZING_O0 ||
         !_exprs_else.empty()) {
@@ -142,7 +142,7 @@ void IfExpr::ast_code_gen()
         }
     }
 
-    std::cout << (char)TT_IF_END; 
+    std::cout << (char)TT_IF_END;
 }
 
 ExpressionType IfExpr::expression_category()

--- a/src/ast/expr/IfExpr.h
+++ b/src/ast/expr/IfExpr.h
@@ -27,7 +27,7 @@ protected:
 public:
     IfExpr(std::vector<Expr *> exprs_then) : _exprs_then(exprs_then) {}
     ~IfExpr() {}
-    
+
     void set_else(std::vector<Expr *> exprs_else) { _exprs_else = exprs_else; }
     /**
      * @brief Generates the IR (Intermediate Representation) code to be

--- a/src/ast/expr/IncrementExpr.cpp
+++ b/src/ast/expr/IncrementExpr.cpp
@@ -49,11 +49,11 @@ void IncrementExpr::ast_code_gen()
         _increment == 0) {
         return;
     }
- 
+
     if (_increment > 0) {
        for (int i = 0; i < _increment; ++i) {
            std::cout << (char)TT_INCREMENT;
-       } 
+       }
     }
     else {
        for (int i = _increment; i < 0; ++i) {

--- a/src/ast/expr/InputExpr.cpp
+++ b/src/ast/expr/InputExpr.cpp
@@ -11,15 +11,15 @@ void InputExpr::code_gen(llvm::Module *M, llvm::IRBuilder<> &B,
                          llvm::BasicBlock *BreakBB)
 {
     llvm::LLVMContext &C = M->getContext();
-    llvm::Type* GetCharArgs[] = { llvm::Type::getInt32Ty(C), 
+    llvm::Type* GetCharArgs[] = { llvm::Type::getInt32Ty(C),
                                   llvm::Type::getInt32PtrTy(C) };
-    llvm::FunctionType *GetCharTy = llvm::FunctionType::get(llvm::Type::getVoidTy(C), 
+    llvm::FunctionType *GetCharTy = llvm::FunctionType::get(llvm::Type::getVoidTy(C),
                                                             GetCharArgs, false);
     llvm::Function *GetCharF = llvm::cast<llvm::Function>(M->getOrInsertFunction("b_getchar", GetCharTy));
-    
+
     llvm::Value* Args[] = {
         B.CreateLoad(ASTInfo::instance()->get_index_ptr()),
-        B.CreatePointerCast(ASTInfo::instance()->get_cells_ptr(), 
+        B.CreatePointerCast(ASTInfo::instance()->get_cells_ptr(),
                             llvm::Type::getInt32Ty(C)->getPointerTo())
     };
 
@@ -31,7 +31,7 @@ void InputExpr::debug_description(int level)
 {
     std::cout.width(level);
     if (ArgsOptions::instance()->has_option(BO_IS_VERBOSE)) {
-        std::cout << "Input Expression - read char" 
+        std::cout << "Input Expression - read char"
                   << std::endl;
     }
     else {

--- a/src/ast/expr/InputExpr.h
+++ b/src/ast/expr/InputExpr.h
@@ -19,7 +19,7 @@
 
 /**
  * @brief Represents the input operator in Brain, aka as: .
- * It calls b_getchar of io.c to interpret input. 
+ * It calls b_getchar of io.c to interpret input.
  */
 class InputExpr : public Expr
 {

--- a/src/ast/general/ASTInfo.cpp
+++ b/src/ast/general/ASTInfo.cpp
@@ -17,7 +17,7 @@ ASTInfo* ASTInfo::instance()
     if (!ASTInfo::_instance) {
         ASTInfo::_instance = new ASTInfo();
     }
-  
+
     return ASTInfo::_instance;
 }
 
@@ -42,7 +42,7 @@ void ASTInfo::code_gen(llvm::Module *M, llvm::IRBuilder<> &B)
         llvm::Constant *InitV = llvm::Constant::getIntegerValue(Ty, Zero);
         ASTInfo::__brain_index_ptr = new llvm::GlobalVariable(*M, Ty, false,
                                           // Keep one copy when linking (weak)
-                                          llvm::GlobalValue::WeakAnyLinkage, 
+                                          llvm::GlobalValue::WeakAnyLinkage,
                                           InitV,
                                           "brain.index");
     }
@@ -58,7 +58,7 @@ void ASTInfo::code_gen(llvm::Module *M, llvm::IRBuilder<> &B)
         llvm::Constant *InitPtr = llvm::ConstantArray::get(ArrTy, Constants);
         ASTInfo::__brain_cells_ptr = new llvm::GlobalVariable(*M, ArrTy, false,
                                           // Keep one copy when linking (weak)
-                                          llvm::GlobalValue::WeakAnyLinkage, 
+                                          llvm::GlobalValue::WeakAnyLinkage,
                                           InitPtr,
                                           "brain.cells");
     }

--- a/src/ast/general/ASTInfo.h
+++ b/src/ast/general/ASTInfo.h
@@ -53,7 +53,7 @@ public:
     /**
      * @returns  A pointer to the array of cells used as the Brain's memory.
      */
-    llvm::GlobalVariable* get_cells_ptr(); 
+    llvm::GlobalVariable* get_cells_ptr();
     /**
      * @brief Controls if the io.ll module is included within the module which
      * is being interpreted, if the module does not uses any function defined in

--- a/src/parser/Parser.cpp
+++ b/src/parser/Parser.cpp
@@ -158,7 +158,7 @@ void Parser::parse(std::vector<Expr *> &exprs, int level)
 
 void Parser::code_gen(llvm::Module *M, llvm::IRBuilder<> &B)
 {
-    ASTInfo::instance()->code_gen(M, B);   
+    ASTInfo::instance()->code_gen(M, B);
 
     for (auto& expr : _exprs) {
         expr->code_gen(M, B, nullptr);


### PR DESCRIPTION
This pull-request aims to save people lifes from tabs `\t`.
I've removed the trailing whitespaces I found and replaced locations that were mixed indented, and that would break style in editors with different tab configurations, such as:

```c
/* Lorem ipsum
	* dolor sit (a tab is here)
  * amet
  * consectetur
  */
```

Always remember: tabs make life harder. :smile: 