### PR TITLE
Solving #46

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,37 @@
-CC=clang++-3.8
+# Having trouble to build your makefile?
+#
+# To build the versions 3.8 or 3.9, you can write:
+# make build-3.8
+# or
+# make build-3.9
+#
+# For the other versions, you can simply pass the CC, GCC and LLVM_CONFIG depending on your clang/LLVM config.
+# For example:
+#
+# make C=clang-3.7 CC=clang++-3.7 LLVM_CONFIG=llvm-config-3.7
+#
+# For the tests and installing the libraries you can do:
+# make install C=clang-3.8
+# and
+# make tests C=clang-3.8
+
+CC=clang++
 GCC=g++
+CLANG=clang
+LLVM_CONFIG=llvm-config
+
 CFLAGS=-O3 -Wall -std=c++1y
 CFLAGS-DEBUG=-O0 -Wall
 BIN=./bin
 
 SUDO=sudo
-MKLIB=bash ./libs/install.sh ./libs
-MKTST=bash ./tests/test_scripts.sh ./tests
+MKLIB=bash ./libs/install.sh ./libs $(CLANG)
+MKTST=bash ./tests/test_scripts.sh ./tests $(CLANG)
 MKBIN=mkdir -p bin
 ROOT=src
 
 SRCS=$(ROOT)/utils/ArgsOptions.cpp $(ROOT)/utils/ArgsHandler.cpp $(ROOT)/utils/Bootstrap.cpp $(ROOT)/parser/Parser.cpp $(ROOT)/ast/general/ASTInfo.cpp $(ROOT)/ast/expr/Expr.cpp $(ROOT)/ast/expr/ShiftExpr.cpp $(ROOT)/ast/expr/IncrementExpr.cpp $(ROOT)/ast/expr/InputExpr.cpp $(ROOT)/ast/expr/OutputExpr.cpp $(ROOT)/ast/expr/LoopExpr.cpp $(ROOT)/ast/expr/ArithmeticExpr.cpp $(ROOT)/ast/expr/DebugExpr.cpp $(ROOT)/ast/expr/BreakExpr.cpp $(ROOT)/ast/expr/IfExpr.cpp $(ROOT)/ast/expr/FloatExpr.cpp $(ROOT)/main.cpp
-CONFIG=`llvm-config-3.8 --cxxflags --ldflags --system-libs --libs core mcjit native nativecodegen irreader linker`
+CONFIG=`$(LLVM_CONFIG) --cxxflags --ldflags --system-libs --libs core mcjit native nativecodegen irreader linker`
 
 all: build
 
@@ -23,6 +43,14 @@ build-gcc: $(SRCS)
 
 build-travis: $(SRCS)
 	$(MKBIN) && $(CC) $(CFLAGS) -DINCOMPATIBLE_LLVM $(SRCS) $(CONFIG) -o $(BIN)/brain
+
+build-3.8: CC=clang++-3.8
+build-3.8: LLVM_CONFIG=llvm-config-3.8
+build-3.8: all
+
+build-3.9: CC=clang++-3.9
+build-3.9: LLVM_CONFIG=llvm-config-3.9
+build-3.9: all
 
 debug: $(SRCS)
 	$(MKBIN) && $(CC) -g $(CFLAGS-DEBUG) $(SRCS) $(CONFIG) -o $(BIN)/brain_debug

--- a/README.md
+++ b/README.md
@@ -99,10 +99,17 @@ To build it, after [installing LLVM](#how-to-build-llvm), execute:
 ```
 $ cd /path/to/brain/src
 $ make
+$ make install
 ```
-You can also change the compiler (tested on `g++` and `clang++`) on the `Makefile` inside the `src` directory.
+Brain will try to run on `clang` and `clang++` automatically. However you can change your `CC` with the commands:
+- `make build-3.8` or `make build-3.9` for LLVM 3.8 and 3.9
+- `make CC=clang++-3.7 LLVM_CONFIG=clang++-3.7` for older versions (3.7 in this case)
 
-After running `make` on it, you can execute:`./brain your_brain_file.b`. Please check the [current status](#current-status) of the project.
+And you can do the same for installing it and running tests:
+- `make install C=clang-3.7`
+- `make tests C=clang-3.7`
+
+After running `make` and `make install` on it, you can execute:`./brain your_brain_file.b`. Please check the [current status](#current-status) of the project.
 
 ### How it has been built
 Brain is based on previous work [https://github.com/luizperes/BrainfuckInterpreter](https://github.com/luizperes/BrainfuckInterpreter) and [https://github.com/Lisapple/BF-Compiler-Tutorial-with-LLVM](https://github.com/Lisapple/BF-Compiler-Tutorial-with-LLVM), now trying to make something more serious: __Turing Complete__, faster, more features/commands and different types.

--- a/libs/install.sh
+++ b/libs/install.sh
@@ -19,8 +19,9 @@ for lib in $files
 do
   filename=$(basename "$lib")
   filename="${filename%.*}"
-  clang-3.8 -S -emit-llvm $lib -o $inc_path/$filename.ll
+  $2 -S -emit-llvm $lib -o $inc_path/$filename.ll
   if [ $? -ne 0 ] ; then
+    echo "Did you pass CLANG as an argument?"
     exit
   else
     echo "Library '$inc_path/$filename' done....."

--- a/tests/test_scripts.sh
+++ b/tests/test_scripts.sh
@@ -2,7 +2,11 @@
 
 cd $1
 
-clang-3.8 test_scripts.c -o test_scripts
+$2 test_scripts.c -o test_scripts
+if [ $? -ne 0 ] ; then
+  echo "Did you pass CLANG as an argument?"
+  exit
+fi
 
 echo "Luiz Peres" | ./test_scripts
 


### PR DESCRIPTION
This PR tries to solve #46.

Now, for building `Brain` we have the following options:
- `> make`
- `> make build-3.8` _// or make build-3.9 for LLVM versions 3.8 and 3.9 respectively_
- `> make CC=clang++-3.7 LLVM_CONFIG=llvm-config-3.7` _// for older versions_

For installing `Brain`, we now have:
- `> make install`
- `> make install CLANG=clang-3.8` _// for specific versions

And finally, for tests we have:
- `> make tests`
- `> make tests CLANG=clang-3.8` _// also for specific versions_

What do you guys think, @rafaelcn, @ryukinix and @haskellcamargo ?