### PR TITLE
Adding custom cell width size

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ Example of the instructions above:
 
 - `--code=<"inline code">`	Sets inline brain code
 - `--io=repl`	Sets the IO module to REPLs style
-- `--out=<filename>`	Sets the output filename
-- `--size=<number>`	Sets the number of cells used by the interpreter
+- `--out=<filename>`	 Sets the output filename
+- `--size=<number>`	 Sets the number of cells used by the interpreter
+- `--size-cell=<number>` Sets the cell width (`8`, `16`, `32`, `64` bits) of each cell
 - `--version`   Shows the current version of Brain
 - `-emit-llvm`	Emits LLVM IR code for the given input
 - `-emit-ast`	Emits the AST for the given input

--- a/libs/io.c
+++ b/libs/io.c
@@ -75,20 +75,90 @@ void b_show_tape(int idx, int *cells, int size) {
     printf("*(%d)\n", idx);
 }
 
-void b_getchar(int idx, int *cells, int size) {
-    cells[idx] = getchar();
+// -------------- 8 bits
+
+void b_getchar_8(char idx, char *cells, int size) {
+    cells[idx] = (char)getchar();
 }
 
-void b_putchar(int idx, int *cells, int size) {
-    putchar(cells[idx]);
+void b_putchar_8(char idx, char *cells, int size) {
+    putchar((int)cells[idx]);
 }
 
-void b_float_print(int idx, int *cells, int size) {
+void b_float_print_8(char idx, char *cells, int size) {
     float value = cells[idx] / 100.0;
     printf("%.2f", value);
 }
 
-void b_debug(int idx, int *cells, int size) {
+void b_debug_8(char idx, char *cells, int size) {
+    printf(
+      "Index Pointer: %d Value at Index Pointer: %d\n",
+      idx,
+      cells[idx]
+    );
+}
+
+// -------------- 16 bits
+
+void b_getchar_16(short idx, short *cells, int size) {
+    cells[idx] = (short)getchar();
+}
+
+void b_putchar_16(short idx, short *cells, int size) {
+    putchar((int)cells[idx]);
+}
+
+void b_float_print_16(short idx, short *cells, int size) {
+    float value = cells[idx] / 100.0;
+    printf("%.2f", value);
+}
+
+void b_debug_16(short idx, short *cells, int size) {
+    printf(
+      "Index Pointer: %d Value at Index Pointer: %d\n",
+      idx,
+      cells[idx]
+    );
+}
+
+// -------------- 32 bits
+
+void b_getchar_32(int idx, int *cells, int size) {
+    cells[idx] = getchar();
+}
+
+void b_putchar_32(int idx, int *cells, int size) {
+    putchar(cells[idx]);
+}
+
+void b_float_print_32(int idx, int *cells, int size) {
+    float value = cells[idx] / 100.0;
+    printf("%.2f", value);
+}
+
+void b_debug_32(int idx, int *cells, int size) {
     b_show_tape(idx, cells, size);
 }
 
+// -------------- 64 bits
+
+void b_getchar_64(long idx, long *cells, int size) {
+    cells[idx] = (long)getchar();
+}
+
+void b_putchar_64(long idx, long *cells, int size) {
+    putchar((int)cells[idx]);
+}
+
+void b_float_print_64(long idx, long *cells, int size) {
+    float value = cells[idx] / 100.0;
+    printf("%.2f", value);
+}
+
+void b_debug_64(long idx, long *cells, int size) {
+    printf(
+      "Index Pointer: %ld Value at Index Pointer: %ld\n",
+      idx,
+      cells[idx]
+    );
+}

--- a/libs/io_16.c
+++ b/libs/io_16.c
@@ -1,0 +1,26 @@
+// -------------- 16 bits
+
+#include <stdio.h>
+
+// you can overwrite those functions! :)
+
+void b_getchar_16(short idx, short *cells, int size) {
+    cells[idx] = (short)getchar();
+}
+
+void b_putchar_16(short idx, short *cells, int size) {
+    putchar((int)cells[idx]);
+}
+
+void b_float_print_16(short idx, short *cells, int size) {
+    float value = cells[idx] / 100.0;
+    printf("%.2f", value);
+}
+
+void b_debug_16(short idx, short *cells, int size) {
+    printf(
+      "Index Pointer: %d Value at Index Pointer: %d\n",
+      idx,
+      cells[idx]
+    );
+}

--- a/libs/io_32.c
+++ b/libs/io_32.c
@@ -1,3 +1,5 @@
+// -------------- 32 bits
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -75,54 +77,6 @@ void b_show_tape(int idx, int *cells, int size) {
     printf("*(%d)\n", idx);
 }
 
-// -------------- 8 bits
-
-void b_getchar_8(char idx, char *cells, int size) {
-    cells[idx] = (char)getchar();
-}
-
-void b_putchar_8(char idx, char *cells, int size) {
-    putchar((int)cells[idx]);
-}
-
-void b_float_print_8(char idx, char *cells, int size) {
-    float value = cells[idx] / 100.0;
-    printf("%.2f", value);
-}
-
-void b_debug_8(char idx, char *cells, int size) {
-    printf(
-      "Index Pointer: %d Value at Index Pointer: %d\n",
-      idx,
-      cells[idx]
-    );
-}
-
-// -------------- 16 bits
-
-void b_getchar_16(short idx, short *cells, int size) {
-    cells[idx] = (short)getchar();
-}
-
-void b_putchar_16(short idx, short *cells, int size) {
-    putchar((int)cells[idx]);
-}
-
-void b_float_print_16(short idx, short *cells, int size) {
-    float value = cells[idx] / 100.0;
-    printf("%.2f", value);
-}
-
-void b_debug_16(short idx, short *cells, int size) {
-    printf(
-      "Index Pointer: %d Value at Index Pointer: %d\n",
-      idx,
-      cells[idx]
-    );
-}
-
-// -------------- 32 bits
-
 void b_getchar_32(int idx, int *cells, int size) {
     cells[idx] = getchar();
 }
@@ -138,27 +92,4 @@ void b_float_print_32(int idx, int *cells, int size) {
 
 void b_debug_32(int idx, int *cells, int size) {
     b_show_tape(idx, cells, size);
-}
-
-// -------------- 64 bits
-
-void b_getchar_64(long idx, long *cells, int size) {
-    cells[idx] = (long)getchar();
-}
-
-void b_putchar_64(long idx, long *cells, int size) {
-    putchar((int)cells[idx]);
-}
-
-void b_float_print_64(long idx, long *cells, int size) {
-    float value = cells[idx] / 100.0;
-    printf("%.2f", value);
-}
-
-void b_debug_64(long idx, long *cells, int size) {
-    printf(
-      "Index Pointer: %ld Value at Index Pointer: %ld\n",
-      idx,
-      cells[idx]
-    );
 }

--- a/libs/io_64.c
+++ b/libs/io_64.c
@@ -1,0 +1,26 @@
+// -------------- 64 bits
+
+#include <stdio.h>
+
+// you can overwrite those functions! :)
+
+void b_getchar_64(long idx, long *cells, int size) {
+    cells[idx] = (long)getchar();
+}
+
+void b_putchar_64(long idx, long *cells, int size) {
+    putchar((int)cells[idx]);
+}
+
+void b_float_print_64(long idx, long *cells, int size) {
+    float value = cells[idx] / 100.0;
+    printf("%.2f", value);
+}
+
+void b_debug_64(long idx, long *cells, int size) {
+    printf(
+      "Index Pointer: %ld Value at Index Pointer: %ld\n",
+      idx,
+      cells[idx]
+    );
+}

--- a/libs/io_8.c
+++ b/libs/io_8.c
@@ -1,0 +1,26 @@
+// -------------- 8 bits
+
+#include <stdio.h>
+
+// you can overwrite those functions! :)
+
+void b_getchar_8(char idx, char *cells, int size) {
+    cells[idx] = (char)getchar();
+}
+
+void b_putchar_8(char idx, char *cells, int size) {
+    putchar((int)cells[idx]);
+}
+
+void b_float_print_8(char idx, char *cells, int size) {
+    float value = cells[idx] / 100.0;
+    printf("%.2f", value);
+}
+
+void b_debug_8(char idx, char *cells, int size) {
+    printf(
+      "Index Pointer: %d Value at Index Pointer: %d\n",
+      idx,
+      cells[idx]
+    );
+}

--- a/src/ast/general/ASTInfo.cpp
+++ b/src/ast/general/ASTInfo.cpp
@@ -41,14 +41,27 @@ llvm::GlobalVariable* ASTInfo::get_cells_size()
     return __brain_cells_size;
 }
 
+llvm::Type* ASTInfo::get_cell_type(llvm::LLVMContext &C)
+{
+    return llvm::Type::getIntNTy(C,
+                                 ArgsOptions::instance()->get_cell_bitsize());
+}
+
+llvm::Type* ASTInfo::get_cell_ptr_type(llvm::LLVMContext &C)
+{
+    return llvm::Type::getIntNPtrTy(C,
+                                    ArgsOptions::instance()->get_cell_bitsize());
+}
+
 void ASTInfo::code_gen(llvm::Module *M, llvm::IRBuilder<> &B)
 {
     llvm::LLVMContext &context = M->getContext();
 
     if (!__brain_index_ptr) {
         // Create global variable |brain.index|
-        llvm::Type *Ty = llvm::Type::getInt32Ty(context);
-        const llvm::APInt Zero = llvm::APInt(32, 0); // int32 0
+        llvm::Type *Ty = ASTInfo::_instance->get_cell_type(context);
+        const llvm::APInt Zero = llvm::APInt(ArgsOptions::instance()->get_cell_bitsize(),
+                                             0); // int 8, 16, 32 or with value of 0
         llvm::Constant *InitV = llvm::Constant::getIntegerValue(Ty, Zero);
         ASTInfo::__brain_index_ptr = new llvm::GlobalVariable(*M, Ty, false,
                                           // Keep one copy when linking (weak)
@@ -59,8 +72,8 @@ void ASTInfo::code_gen(llvm::Module *M, llvm::IRBuilder<> &B)
 
     if (!__brain_cells_size) {
         // Create global variable |brain.cells.size|
-        llvm::Type *Ty = llvm::Type::getInt32Ty(context);
-        // Int32 tape size
+        llvm::Type *Ty = ASTInfo::_instance->get_cell_type(context);
+        // int 8, 16, 32 or 64 tape size
         const llvm::APInt Size = llvm::APInt(32, ArgsOptions::instance()->get_cells_size());
         llvm::Constant *InitV = llvm::Constant::getIntegerValue(Ty, Size);
         ASTInfo::__brain_cells_size = new llvm::GlobalVariable(*M, Ty, false,
@@ -72,11 +85,13 @@ void ASTInfo::code_gen(llvm::Module *M, llvm::IRBuilder<> &B)
 
     if (!__brain_cells_ptr) {
         // Create |brain.cells|
-        auto *ArrTy = llvm::ArrayType::get(llvm::Type::getInt32Ty(context),
+        auto *ArrTy = llvm::ArrayType::get(ASTInfo::_instance->get_cell_type(context),
                                            ArgsOptions::instance()->get_cells_size());
         // Create a vector of _k_cells_size items equal to 0
-        std::vector<llvm::Constant *> constants(ArgsOptions::instance()->get_cells_size(),
-                                                B.getInt32(0));
+        std::vector<llvm::Constant *> constants(
+            ArgsOptions::instance()->get_cells_size(),
+            B.getIntN(ArgsOptions::instance()->get_cell_bitsize(), 0)
+        );
         llvm::ArrayRef<llvm::Constant *> Constants = llvm::ArrayRef<llvm::Constant *>(constants);
         llvm::Constant *InitPtr = llvm::ConstantArray::get(ArrTy, Constants);
         ASTInfo::__brain_cells_ptr = new llvm::GlobalVariable(*M, ArrTy, false,

--- a/src/ast/general/ASTInfo.cpp
+++ b/src/ast/general/ASTInfo.cpp
@@ -72,7 +72,7 @@ void ASTInfo::code_gen(llvm::Module *M, llvm::IRBuilder<> &B)
 
     if (!__brain_cells_size) {
         // Create global variable |brain.cells.size|
-        llvm::Type *Ty = ASTInfo::_instance->get_cell_type(context);
+        llvm::Type *Ty = llvm::Type::getInt32Ty(context);
         // int 8, 16, 32 or 64 tape size
         const llvm::APInt Size = llvm::APInt(32, ArgsOptions::instance()->get_cells_size());
         llvm::Constant *InitV = llvm::Constant::getIntegerValue(Ty, Size);

--- a/src/ast/general/ASTInfo.h
+++ b/src/ast/general/ASTInfo.h
@@ -62,6 +62,15 @@ public:
      */
     llvm::GlobalVariable* get_cells_size();
     /**
+     * @returns  The type representing the bitsize of each cell (8, 16, 32 or 64 bits).
+     */
+    llvm::Type* get_cell_type(llvm::LLVMContext &C);
+    /**
+     * @returns  The pointer type representing the bitsize of each
+     * cell (8, 16, 32 or 64 bits).
+     */
+    llvm::Type* get_cell_ptr_type(llvm::LLVMContext &C);
+    /**
      * @brief Controls if the io.ll module is included within the module which
      * is being interpreted, if the module does not uses any function defined in
      * io.c so it won't include io.ll in their .ll code.

--- a/src/ast/instr/ArithmeticInstr.cpp
+++ b/src/ast/instr/ArithmeticInstr.cpp
@@ -13,7 +13,8 @@ void ArithmeticInstr::code_gen(llvm::Module *M, llvm::IRBuilder<> &B,
                               llvm::BasicBlock *BreakBB)
 {
     llvm::Value *IdxV = B.CreateLoad(ASTInfo::instance()->get_index_ptr());
-    llvm::Value* Idxs[] = { B.getInt32(0), IdxV };
+    llvm::Value* Idxs[] = { B.getIntN(ArgsOptions::instance()->get_cell_bitsize(), 0),
+                            IdxV };
     llvm::ArrayRef<llvm::Value *> IdxsArr(Idxs);
     llvm::Value *CellPtr = B.CreateGEP(ASTInfo::instance()->get_cells_ptr(),
                                        IdxsArr);
@@ -21,8 +22,10 @@ void ArithmeticInstr::code_gen(llvm::Module *M, llvm::IRBuilder<> &B,
     llvm::Value *CellV = B.CreateLoad(CellPtr);
 
     // Load index value - 1
-    llvm::Value *IdxPreV = B.CreateAdd(IdxV, B.getInt32(-1));
-    llvm::Value* Idxs2[] = { B.getInt32(0), IdxPreV };
+    llvm::Value *IdxPreV = B.CreateAdd(IdxV,
+                                       B.getIntN(ArgsOptions::instance()->get_cell_bitsize(), -1));
+    llvm::Value* Idxs2[] = { B.getIntN(ArgsOptions::instance()->get_cell_bitsize(), 0),
+                             IdxPreV };
     llvm::ArrayRef<llvm::Value *> IdxsArr2(Idxs2);
     llvm::Value *CellPtr2 = B.CreateGEP(ASTInfo::instance()->get_cells_ptr(),
                                         IdxsArr2);

--- a/src/ast/instr/DebugInstr.cpp
+++ b/src/ast/instr/DebugInstr.cpp
@@ -11,15 +11,20 @@ void DebugInstr::code_gen(llvm::Module *M, llvm::IRBuilder<> &B,
                          llvm::BasicBlock *BreakBB)
 {
   llvm::LLVMContext &C = M->getContext();
-  llvm::Type* DebugArgs[] = { llvm::Type::getInt32Ty(C),
-                              llvm::Type::getInt32PtrTy(C),
+  llvm::Type* DebugArgs[] = { ASTInfo::instance()->get_cell_type(C),
+                              ASTInfo::instance()->get_cell_ptr_type(C),
                               llvm::Type::getInt32Ty(C) };
   llvm::FunctionType *DebugTy = llvm::FunctionType::get(llvm::Type::getVoidTy(C), DebugArgs, false);
-  llvm::Function *DebugF = llvm::cast<llvm::Function>(M->getOrInsertFunction("b_debug", DebugTy));
+  llvm::Function *DebugF = llvm::cast<llvm::Function>(
+      M->getOrInsertFunction(
+        "b_debug_" + std::to_string(ArgsOptions::instance()->get_cell_bitsize()),
+        DebugTy
+      )
+  );
   llvm::Value* Args[] = {
     B.CreateLoad(ASTInfo::instance()->get_index_ptr()),
     B.CreatePointerCast(ASTInfo::instance()->get_cells_ptr(),
-                        llvm::Type::getInt32Ty(C)->getPointerTo()),
+                        ASTInfo::instance()->get_cell_type(C)->getPointerTo()),
     B.CreateLoad(ASTInfo::instance()->get_cells_size())
   };
   llvm::ArrayRef<llvm::Value *> ArgsArr(Args);

--- a/src/ast/instr/FloatInstr.cpp
+++ b/src/ast/instr/FloatInstr.cpp
@@ -11,23 +11,26 @@ void FloatInstr::code_gen(llvm::Module *M, llvm::IRBuilder<> &B,
                          llvm::BasicBlock *BreakBB)
 {
     llvm::LLVMContext &C = M->getContext();
-    llvm::Type* PutCharArgs[] = { llvm::Type::getInt32Ty(C),
-                                  llvm::Type::getInt32PtrTy(C),
+    llvm::Type* PutCharArgs[] = { ASTInfo::instance()->get_cell_type(C),
+                                  ASTInfo::instance()->get_cell_ptr_type(C),
                                   llvm::Type::getInt32Ty(C) };
 
     llvm::FunctionType *FloatPrintTy =
             llvm::FunctionType::get(llvm::Type::getVoidTy(C), PutCharArgs,
                                     false);
-    llvm::Function *FloatPrintF =
-            llvm::cast<llvm::Function>(M->getOrInsertFunction("b_float_print",
-                                                              FloatPrintTy));
+    llvm::Function *FloatPrintF = llvm::cast<llvm::Function>(
+        M->getOrInsertFunction(
+            "b_float_print_" + std::to_string(ArgsOptions::instance()->get_cell_bitsize()),
+            FloatPrintTy
+        )
+    );
 
     // Creating the arguments which will be passed to the called function in
     // io.c
     llvm::Value* Args[] = {
         B.CreateLoad(ASTInfo::instance()->get_index_ptr()),
         B.CreatePointerCast(ASTInfo::instance()->get_cells_ptr(),
-                            llvm::Type::getInt32Ty(C)->getPointerTo()),
+                            ASTInfo::instance()->get_cell_type(C)->getPointerTo()),
         B.CreateLoad(ASTInfo::instance()->get_cells_size())
     };
 

--- a/src/ast/instr/IfInstr.cpp
+++ b/src/ast/instr/IfInstr.cpp
@@ -21,13 +21,13 @@ void IfInstr::code_gen(llvm::Module *M, llvm::IRBuilder<> &B,
     // Get the current cell adress
     llvm::Value *IdxV = B.CreateLoad(ASTInfo::instance()->get_index_ptr());
     llvm::Value *CellPtr = B.CreateGEP(B.CreatePointerCast(ASTInfo::instance()->get_cells_ptr(),
-                                                           // Cast to int32*
-                                                           llvm::Type::getInt32Ty(C)->getPointerTo()),
+                                       // Cast to int 8*, 16*, 32* or 64*
+                                       ASTInfo::instance()->get_cell_type(C)->getPointerTo()),
                                        IdxV);
     llvm::Value *NEZeroCond = B.CreateICmpNE(B.CreateLoad(CellPtr),
                                              // is cell signed int not equal
                                              // to zero?
-                                             B.getInt32(0));
+                                             B.getIntN(ArgsOptions::instance()->get_cell_bitsize(), 0));
 
     if (ArgsOptions::instance()->get_optimization() == BO_IS_OPTIMIZING_O0 ||
         !_instrs_else.empty()) {

--- a/src/ast/instr/IncrementInstr.cpp
+++ b/src/ast/instr/IncrementInstr.cpp
@@ -15,13 +15,16 @@ void IncrementInstr::code_gen(llvm::Module *M, llvm::IRBuilder<> &B,
         return;
     }
 
-    llvm::Value* Idxs[] = { B.getInt32(0), B.CreateLoad(ASTInfo::instance()->get_index_ptr()) };
+    llvm::Value* Idxs[] = { B.getIntN(ArgsOptions::instance()->get_cell_bitsize(), 0),
+                            B.CreateLoad(ASTInfo::instance()->get_index_ptr()) };
     llvm::ArrayRef<llvm::Value *> IdxsArr(Idxs);
     llvm::Value *CellPtr = B.CreateGEP(ASTInfo::instance()->get_cells_ptr(), IdxsArr);
     // Load cell value
     llvm::Value *CellV = B.CreateLoad(CellPtr);
     // Add |_increment| to cell value and save the value
-    B.CreateStore(B.CreateAdd(CellV, B.getInt32(_increment)), CellPtr);
+    B.CreateStore(B.CreateAdd(CellV,
+                    B.getIntN(ArgsOptions::instance()->get_cell_bitsize(), _increment)),
+                  CellPtr);
 }
 
 void IncrementInstr::debug_description(int level)

--- a/src/ast/instr/InputInstr.cpp
+++ b/src/ast/instr/InputInstr.cpp
@@ -11,17 +11,22 @@ void InputInstr::code_gen(llvm::Module *M, llvm::IRBuilder<> &B,
                          llvm::BasicBlock *BreakBB)
 {
     llvm::LLVMContext &C = M->getContext();
-    llvm::Type* GetCharArgs[] = { llvm::Type::getInt32Ty(C),
-                                  llvm::Type::getInt32PtrTy(C),
+    llvm::Type* GetCharArgs[] = { ASTInfo::instance()->get_cell_type(C),
+                                  ASTInfo::instance()->get_cell_ptr_type(C),
                                   llvm::Type::getInt32Ty(C) };
     llvm::FunctionType *GetCharTy = llvm::FunctionType::get(llvm::Type::getVoidTy(C),
                                                             GetCharArgs, false);
-    llvm::Function *GetCharF = llvm::cast<llvm::Function>(M->getOrInsertFunction("b_getchar", GetCharTy));
+    llvm::Function *GetCharF = llvm::cast<llvm::Function>(
+        M->getOrInsertFunction(
+            "b_getchar_" + std::to_string(ArgsOptions::instance()->get_cell_bitsize()),
+            GetCharTy
+        )
+    );
 
     llvm::Value* Args[] = {
         B.CreateLoad(ASTInfo::instance()->get_index_ptr()),
         B.CreatePointerCast(ASTInfo::instance()->get_cells_ptr(),
-                            llvm::Type::getInt32Ty(C)->getPointerTo()),
+                            ASTInfo::instance()->get_cell_type(C)->getPointerTo()),
         B.CreateLoad(ASTInfo::instance()->get_cells_size())
     };
 

--- a/src/ast/instr/OutputInstr.cpp
+++ b/src/ast/instr/OutputInstr.cpp
@@ -11,15 +11,20 @@ void OutputInstr::code_gen(llvm::Module *M, llvm::IRBuilder<> &B,
                           llvm::BasicBlock *BreakBB)
 {
     llvm::LLVMContext &C = M->getContext();
-    llvm::Type* PutCharArgs[] = { llvm::Type::getInt32Ty(C),
-                                  llvm::Type::getInt32PtrTy(C),
+    llvm::Type* PutCharArgs[] = { ASTInfo::instance()->get_cell_type(C),
+                                  ASTInfo::instance()->get_cell_ptr_type(C),
                                   llvm::Type::getInt32Ty(C) };
     llvm::FunctionType *PutCharTy = llvm::FunctionType::get(llvm::Type::getVoidTy(C), PutCharArgs, false);
-    llvm::Function *PutCharF = llvm::cast<llvm::Function>(M->getOrInsertFunction("b_putchar", PutCharTy));
+    llvm::Function *PutCharF = llvm::cast<llvm::Function>(
+        M->getOrInsertFunction(
+            "b_putchar_" + std::to_string(ArgsOptions::instance()->get_cell_bitsize()),
+            PutCharTy
+        )
+    );
     llvm::Value* Args[] = {
         B.CreateLoad(ASTInfo::instance()->get_index_ptr()),
         B.CreatePointerCast(ASTInfo::instance()->get_cells_ptr(),
-                            llvm::Type::getInt32Ty(C)->getPointerTo()),
+                            ASTInfo::instance()->get_cell_type(C)->getPointerTo()),
         B.CreateLoad(ASTInfo::instance()->get_cells_size())
     };
     llvm::ArrayRef<llvm::Value *> ArgsArr(Args);

--- a/src/ast/instr/ShiftInstr.cpp
+++ b/src/ast/instr/ShiftInstr.cpp
@@ -17,7 +17,7 @@ void ShiftInstr::code_gen(llvm::Module *M, llvm::IRBuilder<> &B,
     }
 
     if (_jump) {
-        llvm::Value* Idxs[] = { B.getInt32(0),
+        llvm::Value* Idxs[] = { B.getIntN(ArgsOptions::instance()->get_cell_bitsize(), 0),
            B.CreateLoad(ASTInfo::instance()->get_index_ptr()) };
         llvm::ArrayRef<llvm::Value *> IdxsArr(Idxs);
         llvm::Value *CellPtr = B.CreateGEP(ASTInfo::instance()->get_cells_ptr(),
@@ -31,8 +31,13 @@ void ShiftInstr::code_gen(llvm::Module *M, llvm::IRBuilder<> &B,
         // Load index value
         llvm::Value *IdxV = B.CreateLoad(ASTInfo::instance()->get_index_ptr());
         // Add |_step| to index and save the value
-        B.CreateStore(B.CreateAdd(IdxV, B.getInt32(_step)),
-            ASTInfo::instance()->get_index_ptr());
+        B.CreateStore(
+            B.CreateAdd(
+                IdxV,
+                B.getIntN(ArgsOptions::instance()->get_cell_bitsize(), _step)
+            ),
+            ASTInfo::instance()->get_index_ptr()
+        );
     }
 }
 

--- a/src/utils/ArgsHandler.cpp
+++ b/src/utils/ArgsHandler.cpp
@@ -46,6 +46,8 @@ void ArgsHandler::handle(int argc, char **argv)
                       << "--version\t\tShows the current version of Brain\n"
                       << "--size=<number>\t\tSets the number of cells used by \
 the interpreter\n"
+                      << "--size-cell=<number>\tSets the number of bits \
+(8, 16, 32, 64) of each cell\n"
                       << "-emit-llvm\t\tEmits LLVM IR code for the given input\n"
                       << "-emit-ast\t\tEmits the AST for the given input\n"
                       << "-emit-code\t\tEmits an optimized code for the given \
@@ -116,6 +118,13 @@ input\n"
              */
             int cells_size = std::atoi(str.substr(7, str.size()-7).c_str());
             ArgsOptions::instance()->set_cells_size(cells_size);
+        }
+        else if (str.size() > 11 && str.compare(0, 12, "--size-cell=") == 0) {
+            /* Specified a cell size of 8, 16, 32 or 64 bits.
+             * The default is 32 bits.
+             */
+            int cell_bitsize = std::atoi(str.substr(12, str.size()-12).c_str());
+            ArgsOptions::instance()->set_cell_bitsize(cell_bitsize);
         }
         else if (str.size() > 6 && str.compare(0, 7, "--code=") == 0) {
             _string_file = str.substr(7, str.size()-7);

--- a/src/utils/ArgsOptions.cpp
+++ b/src/utils/ArgsOptions.cpp
@@ -16,6 +16,7 @@ ArgsOptions* ArgsOptions::instance()
         ArgsOptions::_instance = new ArgsOptions();
         ArgsOptions::_instance->set_cells_size(100);
         ArgsOptions::_instance->set_io_option(IO_REGULAR);
+        ArgsOptions::_instance->set_cell_bitsize(32);
     }
 
     return _instance;
@@ -54,6 +55,26 @@ void ArgsOptions::set_cells_size(int cells_size)
 int ArgsOptions::get_cells_size()
 {
     return _k_cells_size;
+}
+
+void ArgsOptions::set_cell_bitsize(int cell_bitsize)
+{
+    switch (cell_bitsize) {
+        case 8:
+        case 16:
+        // 32 is the default
+        case 64:
+          _k_cell_bitsize = cell_bitsize;
+          break;
+        default:
+          _k_cell_bitsize = 32;
+          break;
+    }
+}
+
+int ArgsOptions::get_cell_bitsize()
+{
+    return _k_cell_bitsize;
 }
 
 void ArgsOptions::set_io_option(int type_io)

--- a/src/utils/ArgsOptions.h
+++ b/src/utils/ArgsOptions.h
@@ -52,6 +52,8 @@ private:
     int _options;
     /// Number of cells available to Brain interpreter.
     int _k_cells_size;
+    /// Number of bits of each cell of the tape.
+    int _k_cell_bitsize;
     /// Type for the io library
     int _type_io;
 public:
@@ -85,6 +87,18 @@ public:
      * as the Brain memory.
      */
     int get_cells_size();
+    /**
+     * @brief set_cell_bitsize Sets the bitsize of Brain's cells.
+     * @param cell_bitsize An integer representing the bitsize of each cell
+     * of the Brain tape.
+     */
+    void set_cell_bitsize(int cell_bitsize);
+    /**
+     * @brief get_cell_bitsize
+     * @return An integer corresponding with the bitsize of each cell of the
+     * tape.
+     */
+    int get_cell_bitsize();
     /**
      * @brief Returns the optimization level to compile Brain files.
      * @returns A BrainOption representing the level of optimization.

--- a/src/utils/Bootstrap.cpp
+++ b/src/utils/Bootstrap.cpp
@@ -68,8 +68,10 @@ int Bootstrap::init(int argc, char** argv)
 #endif // IS_DEBUG
 
     // Create the main function: "i32 @main()"
-    auto *MainF = llvm::cast<llvm::Function>(module->getOrInsertFunction("main",
-                                                                        llvm::Type::getInt32Ty(llvm_context)));
+    auto *MainF = llvm::cast<llvm::Function>(
+        module->getOrInsertFunction("main",
+        ASTInfo::instance()->get_cell_type(llvm_context))
+    );
 
     // Create the entry block
     auto *basic_block = llvm::BasicBlock::Create(llvm_context,
@@ -87,7 +89,7 @@ int Bootstrap::init(int argc, char** argv)
     parser.code_gen(module, builder);
 
     // Return 0 to the "main" function.
-    builder.CreateRet(builder.getInt32(0));
+    builder.CreateRet(builder.getIntN(ArgsOptions::instance()->get_cell_bitsize(), 0));
 
 #ifdef IS_DEBUG
     llvm::verifyModule(*module, &dumpStrOstreamDebug);

--- a/src/utils/Bootstrap.cpp
+++ b/src/utils/Bootstrap.cpp
@@ -29,7 +29,9 @@ int Bootstrap::init(int argc, char** argv)
     Parser parser(args_handler.get_string_file());
 
     io_lib = std::string(getenv("HOME")) + "/.brain/lib/";
-    io_lib += ArgsOptions::instance()->get_io_option() == IO_REPL ? "io_repl.ll" : "io.ll"; 
+    io_lib += ArgsOptions::instance()->get_io_option() == IO_REPL ?
+        "io_repl.ll" :
+        "io_" + std::to_string(ArgsOptions::instance()->get_cell_bitsize()) + ".ll";
 
     if (ArgsOptions::instance()->has_option(BO_IS_EMITTING_CODE)) {
         parser.ast_code_gen();


### PR DESCRIPTION
Giving support to different cell width (`8`, `16`, `32` and `64` bits) adding the new command line argument `--size-cell=<number>`, where number is the number of bits of the cell, as per #64 