### PR TITLE
Fixes a memory leak with the Boostrap instance

### DIFF
--- a/src/utils/Bootstrap.cpp
+++ b/src/utils/Bootstrap.cpp
@@ -14,7 +14,8 @@ Bootstrap::Bootstrap()
 {
 }
 
-Bootstrap::~Bootstrap() {
+Bootstrap::~Bootstrap()
+{
     delete _instance;
 }
 

--- a/src/utils/Bootstrap.cpp
+++ b/src/utils/Bootstrap.cpp
@@ -14,6 +14,10 @@ Bootstrap::Bootstrap()
 {
 }
 
+Bootstrap::~Bootstrap() {
+    delete _instance;
+}
+
 Bootstrap* Bootstrap::instance()
 {
     if (_instance == nullptr) {

--- a/src/utils/Bootstrap.h
+++ b/src/utils/Bootstrap.h
@@ -67,7 +67,7 @@ private:
 
     static Bootstrap* _instance;
 public:
-    ~Bootstrap() {}
+    ~Bootstrap();
 
     /**
      * @brief Returns the instance of Bootstrap class if the member _instance is


### PR DESCRIPTION
_instance variable was not being deleted after execution of Brain, this should fix this.

Signed-off-by: Rafael C. Nunes <rafaelnunes@engineer.com>